### PR TITLE
Automatic dependency updates

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.1.2
 homepage: https://github.com/Skycoder42/dart_test_tools
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.8.1
 
 executables:
   generate-build-number: generate_build_number


### PR DESCRIPTION
```

No changes to pubspec.yaml!
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (86.0.0 available)
  analyzer 7.6.0 (8.0.0 available)
  analyzer_plugin 0.13.4 (0.13.5 available)
  characters 1.4.0 (1.4.1 available)
  leak_tracker 10.0.9 (11.0.1 available)
  leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
  leak_tracker_testing 3.0.1 (3.0.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  petitparser 6.1.0 (7.0.0 available)
  test 1.25.15 (1.26.3 available)
  test_api 0.7.4 (0.7.7 available)
  test_core 0.6.8 (0.6.12 available)
  vector_math 2.1.4 (2.2.0 available)
  vm_service 15.0.0 (15.0.2 available)
  xml 6.5.0 (6.6.0 available)
No dependencies changed.
16 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
