### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.3] - 2025-07-26
+### Changed
+- Updated min sdk version to ^3.8.0
+- Updated dependencies
+
 ## [6.1.3-pre.4] - 2025-07-26
 ## [6.1.3-pre.3] - 2025-07-25
 ## [6.1.3-pre.2] - 2025-07-25
@@ -421,6 +426,7 @@ have been added:
 ### Added
 - Initial release
 
+[6.1.3]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.3-pre.4...v6.1.3
 [6.1.3-pre.4]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.3-pre.3...v6.1.3-pre.4
 [6.1.3-pre.3]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.3-pre.2...v6.1.3-pre.3
 [6.1.3-pre.2]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.3-pre.1...v6.1.3-pre.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dart_test_tools
 description: Additional tools and helpers for writing dart unit tests and GitHub Actions Workflows.
-version: 6.1.3-pre.4
+version: 6.1.3
 homepage: https://github.com/Skycoder42/dart_test_tools
 
 environment:
-  sdk: ^3.8.1
+  sdk: ^3.8.0
 
 executables:
   generate-build-number: generate_build_number
@@ -26,7 +26,7 @@ dependencies:
   code_builder: ^4.10.1
   collection: ^1.19.1
   crypto: ^3.0.6
-  custom_lint_builder: ^0.7.6
+  custom_lint_builder: ^0.8.0
   dotenv: ^4.2.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dart_test_tools to ^3.8.0
### Dependency Updates
```

Changed 1 constraint in pubspec.yaml:
  custom_lint_builder: ^0.7.6 -> ^0.8.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (86.0.0 available)
  analyzer 7.6.0 (8.0.0 available)
  analyzer_plugin 0.13.4 (0.13.5 available)
  characters 1.4.0 (1.4.1 available)
> custom_lint 0.8.0 (was 0.7.6)
> custom_lint_builder 0.8.0 (was 0.7.6)
> custom_lint_core 0.8.0 (was 0.7.5)
  leak_tracker 10.0.9 (11.0.1 available)
  leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
  leak_tracker_testing 3.0.1 (3.0.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  petitparser 6.1.0 (7.0.0 available)
  test 1.25.15 (1.26.3 available)
  test_api 0.7.4 (0.7.7 available)
  test_core 0.6.8 (0.6.12 available)
  vector_math 2.1.4 (2.2.0 available)
  vm_service 15.0.0 (15.0.2 available)
  xml 6.5.0 (6.6.0 available)
Changed 3 dependencies!
16 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
