### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.2] - 2025-08-15
+### Changed
+- Updated min sdk version to ^3.9.0
+- Updated dependencies
+
 ## [6.2.1] - 2025-07-30
 ### Changed
 - Allow configuration if flutter compat is needed or not
@@ -422,6 +427,7 @@ have been added:
 ### Added
 - Initial release
 
+[6.2.2]: https://github.com/Skycoder42/dart_test_tools/compare/v6.2.1...v6.2.2
 [6.2.1]: https://github.com/Skycoder42/dart_test_tools/compare/v6.2.0...v6.2.1
 [6.2.0]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.2...v6.2.0
 [6.1.2]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.1...v6.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dart_test_tools
 description: Additional tools and helpers for writing dart unit tests and GitHub Actions Workflows.
-version: 6.2.1
+version: 6.2.2
 homepage: https://github.com/Skycoder42/dart_test_tools
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.9.0
 
 executables:
   generate-build-number: generate_build_number
@@ -41,7 +41,7 @@ dependencies:
   stack_trace: ^1.12.1
   stream_channel: ^2.1.4
   synchronized: ^3.4.0
-  test: ^1.25.15
+  test: ^1.26.2
   xml: ^6.5.0
   yaml: ^3.1.3
   yaml_edit: ^2.2.2
@@ -52,7 +52,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   freezed: ^3.2.0
   html: ^0.15.6
-  http: ^1.4.0
+  http: ^1.5.0
   json_serializable: ^6.10.0
   lints: ^6.0.0
 


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dart_test_tools to ^3.9.0
### Dependency Updates
```

Changed 2 constraints in pubspec.yaml:
  test: ^1.25.15 -> ^1.26.2
  http: ^1.4.0 -> ^1.5.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (88.0.0 available)
  analyzer 7.6.0 (8.1.1 available)
  analyzer_plugin 0.13.4 (0.13.7 available)
  build 3.0.0 (3.0.1 available)
  build_resolvers 3.0.0 (3.0.1 available)
  build_runner 2.6.0 (2.6.1 available)
  build_runner_core 9.2.0 (9.2.1 available)
  characters 1.4.0 (1.4.1 available)
  dart_style 3.1.1 (3.1.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  petitparser 6.1.0 (7.0.0 available)
  test 1.26.2 (1.26.3 available)
  test_api 0.7.6 (0.7.7 available)
  test_core 0.6.11 (0.6.12 available)
  xml 6.5.0 (6.6.0 available)
No dependencies changed.
16 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
