### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.3] - 2025-09-15
+### Changed
+- Updated min sdk version to ^3.9.0
+- Updated dependencies
+
 ## [6.2.2] - 2025-08-15
 ### Changed
 - Updated min sdk version to ^3.9.0
@@ -427,6 +432,7 @@ have been added:
 ### Added
 - Initial release
 
+[6.2.3]: https://github.com/Skycoder42/dart_test_tools/compare/v6.2.2...v6.2.3
 [6.2.2]: https://github.com/Skycoder42/dart_test_tools/compare/v6.2.1...v6.2.2
 [6.2.1]: https://github.com/Skycoder42/dart_test_tools/compare/v6.2.0...v6.2.1
 [6.2.0]: https://github.com/Skycoder42/dart_test_tools/compare/v6.1.2...v6.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_test_tools
 description: Additional tools and helpers for writing dart unit tests and GitHub Actions Workflows.
-version: 6.2.2
+version: 6.2.3
 homepage: https://github.com/Skycoder42/dart_test_tools
 
 environment:
@@ -18,12 +18,12 @@ executables:
 dependencies:
   analyzer: '>=7.6.0 <9.0.0'
   args: ^2.7.0
-  build: ^3.0.2
+  build: ^3.1.0
   build_config: ^1.2.0
   change: ^0.7.5
   checked_yaml: ^2.0.4
   cider: ^0.2.8
-  code_builder: ^4.10.1
+  code_builder: ^4.11.0
   collection: ^1.19.1
   crypto: ^3.0.6
   custom_lint_builder: ^0.8.0
@@ -48,12 +48,12 @@ dependencies:
   yaml_writer: ^2.1.0
 
 dev_dependencies:
-  build_runner: ^2.7.0
+  build_runner: ^2.7.1
   flutter_lints: ^6.0.0
-  freezed: ^3.2.0
+  freezed: ^3.2.3
   html: ^0.15.6
   http: ^1.5.0
-  json_serializable: ^6.11.0
+  json_serializable: ^6.11.1
   lints: ^6.0.0
 
 cider:


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dart_test_tools to ^3.9.0
### Dependency Updates
```

Changed 5 constraints in pubspec.yaml:
  build: ^3.0.2 -> ^3.1.0
  code_builder: ^4.10.1 -> ^4.11.0
  build_runner: ^2.7.0 -> ^2.7.1
  freezed: ^3.2.0 -> ^3.2.3
  json_serializable: ^6.11.0 -> ^6.11.1
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (88.0.0 available)
  analyzer 7.6.0 (8.1.1 available)
  analyzer_plugin 0.13.4 (0.13.7 available)
  build 3.1.0 (4.0.0 available)
  build_resolvers 3.0.3 (3.0.4 available)
  build_runner 2.7.1 (2.8.0 available)
  build_runner_core 9.3.1 (9.3.2 available)
  characters 1.4.0 (1.4.1 available)
  custom_lint 0.8.0 (0.8.1 available)
  custom_lint_builder 0.8.0 (0.8.1 available)
  custom_lint_core 0.8.0 (0.8.1 available)
  custom_lint_visitor 1.0.0+7.7.0 (1.0.0+8.1.1 available)
  dart_style 3.1.1 (3.1.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  source_gen 4.0.0 (4.0.1 available)
  test 1.26.2 (1.26.3 available)
  test_api 0.7.6 (0.7.7 available)
  test_core 0.6.11 (0.6.12 available)
No dependencies changed.
19 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
